### PR TITLE
Additional layout improvements

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -49,15 +49,14 @@ h2, h3, h4, h5, h6 {
 a {outline: 0;}
 a img {border: 0px; text-decoration: none;}
 a:link, a:visited {
-	color: #C74350;
+	color: #7889c0;
 	padding: 0 1px;
 	text-decoration: underline;
 }
 a:hover, a:active {
-	background-color: #C74350;
+	background-color: #7889c0;
 	color: #fff;
 	text-decoration: none;
-	text-shadow: 1px 1px 1px #333;
 }
 	
 /* Paragraphs */
@@ -119,7 +118,7 @@ img.left, figure.left {float: right; margin: 0 0 2em 2em;}
 	}
 	#banner h1 a:hover, #banner h1 a:active {
 		background: none;
-		color: #C74350;
+		color: #7889c0;
 		text-shadow: none;
 	}
 	
@@ -150,11 +149,13 @@ img.left, figure.left {float: right; margin: 0 0 2em 2em;}
 		height: 20px;
 		padding: 5px 1.5em;
 		text-decoration: none;
+		opacity: 0.7;
+		font-weight: bold;
 	}
 	#banner nav a:hover, #banner nav a:active,
 	#banner nav .active a:link, #banner nav .active a:visited {
-		background: #C74451;
-		color: #fff;
+		background: transparent;
+		opacity: 1;
 		text-shadow: none !important;
 	}
  
@@ -219,7 +220,94 @@ input[type="file"] {
 	border: none;
 }
 
-textarea {
+.radio {
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	}
+	
+	.radio > input {
+	display: inline-flex;
+	height: 12px;
+	width: 12px;
+	left: 2px;
+	border-radius: 100%;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	-o-appearance: none;
+	appearance: none;
+	border: 2px solid white;
+	outline: rgb(118, 118, 118) solid 1px;
+	transition-duration: 0.3s;
+	cursor: pointer;
+	background-color: white;
+	padding: 0px !important;
+	margin: 2px 4px 2px 8px !important;
+	color: white
+	}
+	
+	.radio > input:checked {
+	background-color: #7889c0;
+	color: white;
+	}
+	
+	.radio > input:active,
+	.radio > input:hover {
+	background-color: #52608b;
+	}
+	
+	.checkbox {
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	margin-bottom: 16px;
+	}
+	
+	.checkbox > input {
+	display: inline-flex;
+	height: 15px;
+	width: 15px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	-o-appearance: none;
+	appearance: none;
+	border: 1px solid rgb(118, 118, 118);
+	border-radius: 4px;
+	outline: none;
+	transition-duration: 0.3s;
+	cursor: pointer;
+	background-color: white;
+	padding: 0px !important;
+	margin: 0px 6px 2px 0px !important;
+	color: white
+	}
+	
+	.checkbox > input:checked {
+	border: 1px solid rgb(118, 118, 118);
+	background-color: #7889c0;
+	color: white;
+	}
+	
+	.checkbox > input:checked::before {
+	content: '\2713';
+	display: block;
+	text-align: center;
+	color: white;
+	position: absolute;
+	left: 2px;
+	top: -1px;
+	}
+	
+	.checkbox > input:active,
+	.checkbox > input:hover {
+	background-color: #52608b;
+	}
+	
+	textarea {
 	border: 1px solid #aaa;
 	border-radius: 4px;
 }
@@ -238,23 +326,9 @@ button:hover, button:active {
 	background-color: #bbb;
 }
 
-button.danger {
-	color: white;
-	background-color: rgb(199, 68, 81);
-	border: 1px solid rgb(199, 68, 81);
-	font-weight: bold;
-}
-
-button.success {
-	color: white;
-	background-color: rgb(0, 100, 0);
-	border: 1px solid rgb(0, 100, 0);
-	font-weight: bold;
-}
-
 button.danger:hover,
 button.danger:active {
-	background-color: rgb(187, 34, 49);
+	background-color: rgb(170, 157, 159);
 }
 
 button.success:hover,
@@ -277,7 +351,7 @@ button.danger:disabled {
 #extras ul {list-style: none; margin: 0;}
 #extras li {border-bottom: 1px solid #fff;}
 #extras h2 {
-	color: #C74350;
+	color: #7789c0;
 	font-size: 1.429em;
 	margin-bottom: .25em;
 	padding: 0 3px;
@@ -371,7 +445,6 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 	}
 	#posts-list .hentry:hover a:link, #posts-list .hentry:hover a:visited {
 		color: #F6CF74;
-		text-shadow: 1px 1px 1px #333;
 	}
 	
 	#posts-list footer {
@@ -429,8 +502,9 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 	}
 
 	#imageContainer {
-		background-color: #efefef;
+		border: 1px solid #ccc;
 		border-radius: 10px;
+		box-shadow: 2px 2px 10px rgba(0,0,0,0.125);
 	}
 
 	#imageContainer form {
@@ -471,9 +545,13 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 		margin-bottom: 16px;
 	}
 
-	.text-red {
-		color: red;
+	.text-highlight {
+		color: #7889c0;
 		font-weight: bold;
+		border: 1px solid #7889c0;
+		padding: 2px 4px;
+		border-radius: 4px;
+		font-size: 11px;
 	}
 
 	.text-sm {
@@ -553,6 +631,8 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 	#dataMenu .color {
 		width: 18px;
 		height: 18px;
+		border: none;
+		opacity: 0.2;
 	}
 	#dataMenu .elementsN {
 		margin-left: 5px;
@@ -573,7 +653,22 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 		width: 13px!important;
 		height: 13px!important;
 		margin: 3px 0px;
+		border: none;
+	}
+
+	.colorContainer {
+		display: inline-block;
+		position: relative;
+		border-radius: 100%;
+		width: 21px!important;
+		height: 21px!important;
+		top: 1px;
 		border: 1px solid rgb(118, 118, 118);
+		padding: 0px;
+	}
+
+	.colorContainer > input.color {
+		margin: 0px!important;
 	}
 
 	#clearSets {
@@ -620,7 +715,7 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 		display:flex;
 		text-align: left; 
 		padding: 15px; 
-		border:1px solid #ddd; 
+		background-color: #efefef; 
 		border-radius: 10px; 
 		margin-top: 20px;
 	}

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -331,11 +331,6 @@ button.danger:active {
 	background-color: rgb(170, 157, 159);
 }
 
-button.success:hover,
-button.success:active {
-	background-color: rgb(0, 73, 0);
-}
-
 button.success:disabled,
 button.danger:disabled {
 	opacity: 0.5;

--- a/web/index.html
+++ b/web/index.html
@@ -112,8 +112,8 @@ http://www.interactivenn.net/
                             </div>
                             <div>
                                 <button type="button" class="success" id="updateMerge" onclick="startstop()">Start</button>
-                                <button id="downMerge" class="success" onclick="mergeSetsDown();"> < </button>
-                                <button id="upMerge" class="success" onclick="mergeSetsUp();"> > </button>      
+                                <button id="downMerge" class="success" onclick="mergeSetsDown();"> &lt; </button>
+                                <button id="upMerge" class="success" onclick="mergeSetsUp();"> &gt; </button>      
                             </div>                                 
                     <script>                                              
                         function startstop() {
@@ -185,24 +185,24 @@ http://www.interactivenn.net/
                         </div>
                     </div>
                     <div id="rightColumn">
-                        <div id="newFeatures">                                
-                            <input type="checkbox" onchange="togglePercentage()">
-                                <span class="text-sm">Show <b>percentages</b> instead of size</span>
-                                <span behavior="alternate" class="text-red"> (new feature!)</span>
+                        <div id="newFeatures">   
+                            <span class="checkbox">
+                                <input class="checkbox" type="checkbox" onchange="togglePercentage()">
+                                <span class="text-sm">Show <b>percentages</b> instead of size <span class="text-highlight">new feature!</span></span>
                             </input> 
-                            <br>
-                            <span style="margin-left:21px; margin-top: 4px;">Mouse-over numbers highlights their sets</span>
-                            <span behavior="alternate" class="text-red"> (new feature!)</span>
+                            </span>                             
+                            <span style="margin-left:21px; margin-top: 4px;">Mouse-over numbers highlights their sets </span>
+                            <span class="text-highlight">new feature!</span>
                         </div>
                         <div id="nWayMenu"> 
                             <div class="rightColMargin"><strong>Number of Sets: </strong></div>
                         <form>
                             <!--<input type="radio" name="nway" value="1">1-->
-                            <input id="nway2" type="radio" name="nwayRadio" value="2" onclick="firstLoad = true;updateNWay(2);">2
-                            <input id="nway3" type="radio" name="nwayRadio" value="3" onclick="firstLoad = true;updateNWay(3);">3
-                            <input id="nway4" type="radio" name="nwayRadio" value="4" onclick="firstLoad = true;updateNWay(4);">4            
-                            <input id="nway5" type="radio" name="nwayRadio" value="5" onclick="firstLoad = true;updateNWay(5);">5
-                            <input id="nway6" type="radio" name="nwayRadio" value="6" onclick="firstLoad = true;updateNWay(6);">6
+                            <div class="radio"><input id="nway2" type="radio" name="nwayRadio" value="2" onclick="firstLoad = true;updateNWay(2);">2</div>
+                            <div class="radio"><input id="nway3" type="radio" name="nwayRadio" value="3" onclick="firstLoad = true;updateNWay(3);">3</div>
+                            <div class="radio"><input id="nway4" type="radio" name="nwayRadio" value="4" onclick="firstLoad = true;updateNWay(4);">4</div>
+                            <div class="radio"><input id="nway5" type="radio" name="nwayRadio" value="5" onclick="firstLoad = true;updateNWay(5);">5</div>
+                            <div class="radio"><input id="nway6" type="radio" name="nwayRadio" value="6" onclick="firstLoad = true;updateNWay(6);">6</div>
                         </form>
 
                     </div>
@@ -211,7 +211,7 @@ http://www.interactivenn.net/
                         <div id="dataMenu">
                             <span id="divlabelA" class="divLabel">A:</span>
                             <input id="nameA" size="15" maxlength="15" value ="Set A" oninput="updateSetLabel('A');">
-                            <input class="color" id="colorA" onchange="changeColor('A')">
+                            <div class="colorContainer"><input class="color" id="colorA" onchange="changeColor('A')"></div>
                             <div id="elementsA" class="elementsN"></div>                                        
                             <textarea id="inputA" class="input" rows="3" onchange="modified = true;
                                     updateSets('A');" ></textarea>
@@ -219,21 +219,21 @@ http://www.interactivenn.net/
 
                             <span id="divlabelB" class="divLabel">B:</span>
                             <input id="nameB" size="15" maxlength="15" value ="Set B" oninput="updateSetLabel('B');">
-                            <input id="colorB" class="color" onchange="changeColor('B')">
+                            <div class="colorContainer"><input id="colorB" class="color" onchange="changeColor('B')"></div>
                             <div id="elementsB" class="elementsN"></div>                                        
                             <textarea id="inputB" class="input" rows="3" onfocus="" onchange="modified = true;
                             updateSets('B');" onblur=""></textarea>
     
                             <span id="divlabelC" class="divLabel">C:</span>
                             <input id="nameC" size="15" maxlength="15" value ="Set C" oninput="updateSetLabel('C');">
-                            <input id="colorC" class="color" onchange="changeColor('C')">
+                            <div class="colorContainer"><input id="colorC" class="color" onchange="changeColor('C')"></div>
                             <div id="elementsC" class="elementsN"></div>                                        
                             <textarea id="inputC" class="input" rows="3" onchange="modified = true;
                             updateSets('C');" ></textarea>
                             
                             <span id="divlabelD" class="divLabel">D:</span>
                             <input id="nameD" size="15" maxlength="15" value ="Set D" oninput="updateSetLabel('D');">
-                            <input id="colorD" class="color" onchange="changeColor('D')">
+                            <div class="colorContainer"><input id="colorD" class="color" onchange="changeColor('D')"></div>
                             <div id="elementsD" class="elementsN"></div>                                        
                             <textarea id="inputD" class="input" rows="3" onchange="modified = true;
                             updateSets('D');" onfocus="" onblur=""></textarea>                                        
@@ -241,14 +241,14 @@ http://www.interactivenn.net/
 
                             <span id="divlabelE" class="divLabel">E:</span>
                             <input id="nameE" size="15" maxlength="15" value ="Set E" oninput="updateSetLabel('E');">
-                            <input id="colorE" class="color" onchange="changeColor('E')">
+                            <div class="colorContainer"><input id="colorE" class="color" onchange="changeColor('E')"></div>
                             <div id="elementsE" class="elementsN"></div>                                        
                             <textarea id="inputE" class="input" rows="3" onchange="modified = true;
                             updateSets('E');" onfocus="" onblur=""></textarea>                     
     
                             <span id="divlabelF" class="divLabel">F:</span>
                             <input id="nameF" size="15" maxlength="15" value ="Set F" oninput="updateSetLabel('F');">
-                            <input id="colorF" class="color" onchange="changeColor('F')">
+                            <div class="colorContainer"><input id="colorF" class="color" onchange="changeColor('F')"></div>
                             <div id="elementsF" class="elementsN"></div>                                        
                             <textarea id="inputF" class="input" rows="3" onchange="modified = true;
                             updateSets('F');" onfocus="" onblur=""></textarea> 

--- a/web/javascript.js
+++ b/web/javascript.js
@@ -252,6 +252,7 @@ function updateColorBox() {
         var myPicker = new jscolor.color(document.getElementById(boxname), {});
         var color = d3.rgb(d3.select("#elipse" + setname).style("fill")).toString();
         myPicker.fromString(color);
+        document.getElementById(boxname).style.opacity = globalOpacity;
     }
 }
 
@@ -310,6 +311,7 @@ function opacityUp() {
         var setname = originalAllSetsNames[i];
         d3.select("#elipse" + setname).style("fill-opacity", globalOpacity);
     }
+    updateColorBox();
 }
 
 
@@ -325,6 +327,7 @@ function opacityDown() {
         var setname = originalAllSetsNames[i];
         d3.select("#elipse" + setname).style("fill-opacity", globalOpacity);
     }
+    updateColorBox();
 }
 
 
@@ -341,8 +344,8 @@ function resetColor() {
     document.getElementById('nway4').disabled = false;
     document.getElementById('nway5').disabled = false;
     document.getElementById('nway6').disabled = false;
-    updateNWay(nWay);
     globalOpacity = defaultGlobalOpacity;
+    updateNWay(nWay);
 }
 
 


### PR DESCRIPTION
I've changed the buttons back to gray (with just a slight red indicator on the reset buttons), and fixed the diagram background color.

While I was at it, I found a few other ways to simplify the site's color palette and make it less 'busy', without changing any of the original diagram colors.

- Changed navbar location indicator to be opacity based rather than a red background
- Changed highlight color from red to a blue that matches the default blue in the diagram and the VICG logo
- Styled checkbox and radio buttons to match the new accent color
- Changed the 'new feature' color to blue
- Opacity of the color pickers will now match the globalOpacity, which reduces visual clutter a lot

The goal was to remove visual clutter so that the diagram stands out more - let me know what you think!

Some additional tweaks I'm considering:
- lightening the opacity on the 'new feature' border
- styling the color picker popup to be a bit more modern looking
- moving the 'size' boxes for the sets to align with the right side of the data menu (to demphasize them and better separate them from the inputs)
- Aligning the first item in the navbar with 'list merging code' and the left edge of the diagram container and lightening the navbar background slightly. OR: moving to a more modern/clean navbar style where the nav items would be inline with Interactivenn, have a transparent background, and would be aligned to the right side of the viewport. (This would remove the black navbar)

<img width="1092" alt="Screen Shot 2022-01-10 at 10 50 30 AM" src="https://user-images.githubusercontent.com/84106309/148798964-5397b232-d506-4086-9139-3387925fc13d.png">

---
**(continued)**
<img width="1094" alt="Screen Shot 2022-01-10 at 10 50 40 AM" src="https://user-images.githubusercontent.com/84106309/148798987-1ddb77c5-2c02-4f68-bb88-2ad507a52b1e.png">

